### PR TITLE
Fix GUI crash when saving relative code segments

### DIFF
--- a/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
+++ b/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
@@ -520,7 +520,17 @@ namespace knxprod_ns
                 }
                 else
                 {
-                    newAbsCodeSegmentId = ((comboBoxParParMemCodeSegment.SelectedItem as ComboBoxItem).Tag as ApplicationProgramStatic_tCodeAbsoluteSegment).Id;
+                    var tag = (comboBoxParParMemCodeSegment.SelectedItem as ComboBoxItem).Tag;
+                    if(tag is ApplicationProgramStatic_tCodeRelativeSegment)
+                    {
+                        newAbsCodeSegmentId = (tag as ApplicationProgramStatic_tCodeRelativeSegment).Id;
+                    } else if(tag is ApplicationProgramStatic_tCodeAbsoluteSegment)
+                    {
+                        newAbsCodeSegmentId = (tag as ApplicationProgramStatic_tCodeAbsoluteSegment).Id;
+                    } else
+                    {
+                        throw new ArgumentException("Selected code segmet is neither tCodeAbsoluteSegment nor tCodeRelativeSegment");
+                    }
                     ApplicationProgramStatic_tParameter aktParameter = new ApplicationProgramStatic_tParameter();
                     if (TreeViewParameter.SelectedNode != null)
                     {


### PR DESCRIPTION
We were seeing the following error message when saving ApplicationProgram error messages containing relative code segments:
![photo5262853479578320406](https://user-images.githubusercontent.com/34971/156588731-5dae42c4-7d09-4dbc-b9e7-22836f8b205a.jpg)
with the following additional info from VS:
![photo5262853479578320416](https://user-images.githubusercontent.com/34971/156589003-3148571b-9118-4f07-a1af-743689d2d45a.jpg)

This issue occurs due to
```
newAbsCodeSegmentId = ((comboBoxParParMemCodeSegment.SelectedItem as ComboBoxItem).Tag as ApplicationProgramStatic_tCodeAbsoluteSegment).Id;
```

in the save code not taking into account that `Tag` might also be a `ApplicationProgramStatic_tCodeRelativeSegment`.

This pulls request fixes this issue by extracting `newAbsCodeSegmentId` from either `ApplicationProgramStatic_tCodeAbsoluteSegment` or `ApplicationProgramStatic_tCodeRelativeSegment`. For me, this quick fix works so that the error message doesn't appear any more and changes to the offset are saved into the KNXPROD file.