### PR TITLE
Fix another GUI crash when saving relative code segments

### DIFF
--- a/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
+++ b/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
@@ -707,7 +707,7 @@ namespace knxprod_ns
                 else
                 {
                     var tag = (comboBoxParUnionParUnionMemCodeSegment.SelectedItem as ComboBoxItem).Tag;
-                    var codeSegmentId = null;
+                    var codeSegmentId = "";
                     // Find ID for relative or absolute code segment
                     if(tag is ApplicationProgramStatic_tCodeRelativeSegment)
                     {

--- a/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
+++ b/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
@@ -706,18 +706,31 @@ namespace knxprod_ns
                 }
                 else
                 {
-                    newAbsCodeSegment = (comboBoxParUnionParUnionMemCodeSegment.SelectedItem as ComboBoxItem).Tag as ApplicationProgramStatic_tCodeAbsoluteSegment;
+                    var tag = (comboBoxParUnionParUnionMemCodeSegment.SelectedItem as ComboBoxItem).Tag;
+                    var codeSegmentId = null;
+                    // Find ID for relative or absolute code segment
+                    if(tag is ApplicationProgramStatic_tCodeRelativeSegment)
+                    {
+                        codeSegmentId = (tag as ApplicationProgramStatic_tCodeRelativeSegment).Id;
+                    } else if(tag is ApplicationProgramStatic_tCodeAbsoluteSegment)
+                    {
+                        codeSegmentId = (tag as ApplicationProgramStatic_tCodeAbsoluteSegment).Id;
+                    } else
+                    {
+                        throw new ArgumentException("Selected code segment is neither tCodeAbsoluteSegment nor tCodeRelativeSegment");
+                    }
+                    
                     ApplicationProgramStatic_tUnion aktUnion = new ApplicationProgramStatic_tUnion();
                     if (TreeViewParameter.SelectedNode != null)
                     {
                         aktUnion = TreeViewParameter.SelectedNode.Tag as ApplicationProgramStatic_tUnion;
                     }
                     else
-                    {
+                    {newAbsCodeSegment.Id
                         aktUnion = null;
                     }
 
-                    if (CheckIfMemeoryUsed(newAbsCodeSegment.Id, (uint)numericParUnionParUnionMemOffset.Value, (byte)numericParUnionParUnionMemBitOffset.Value, (uint)numericParUnionSizeInBit.Value, aktUnion))
+                    if (CheckIfMemeoryUsed(codeSegmentId, (uint)numericParUnionParUnionMemOffset.Value, (byte)numericParUnionParUnionMemBitOffset.Value, (uint)numericParUnionSizeInBit.Value, aktUnion))
                     {
                         MessageBox.Show("Der Speicherbereich wird bereits von einer anderen Union verwendet", "Speicherbereichsüberschneidung",
                             MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
+++ b/KNXprodEditor/Gui/ApplicationProgramGui/ParameterGui.cs
@@ -726,7 +726,7 @@ namespace knxprod_ns
                         aktUnion = TreeViewParameter.SelectedNode.Tag as ApplicationProgramStatic_tUnion;
                     }
                     else
-                    {newAbsCodeSegment.Id
+                    {
                         aktUnion = null;
                     }
 


### PR DESCRIPTION
Just like pull request #3  this fixes an additional issue for relative code segments (quite similar to the previous one).

![photo5266976192915946502](https://user-images.githubusercontent.com/34971/156894156-72cc7660-e0bb-496a-87dc-b99e0ebe7f10.jpg)

